### PR TITLE
Clarify licensing and disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,9 @@ This project has included a large amount of research (contained in `docs/`), and
 
 Now, you can run the Recursive project scripts directly from the Scripts menu, or by opening them in the Scripting Window. 
 
-**Standard disclaimers:**
+## License
 
-Like any Python scripts, read through them and be generally familiar with what they do before running them. Also, use Git and/or backups when you are using scripts to design. 
-
-Feel free to use/remix these scripts in other projects. I give no warrantees or guarantees of their quality, and your mileage may vary.
-
-
-(...to be continued) -->
+The Recursive project is licensed under the [SIL Open Font License v1.1](OFL.txt).  This is a free software license that permits you to use the font software under a set of conditions.  Please refer to the full text of the license for details about the permissions, conditions, and disclaimers.
 
 ## Collaborators 
 


### PR DESCRIPTION
This PR modifies the README file with an explicit description of the license and replaces the Disclaimer block with text that points to your OFL 1.1 license.  

The license specified disclaimers are likely to be what you want to point out to users rather than drafting your own legalese.  This should cover the disclaimers that you need to provide.  

> THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
OTHER DEALINGS IN THE FONT SOFTWARE.

The README documentation that currently states:

> "Feel free to use/remix these scripts in other projects."

is not entirely consistent with the SIL OFL 1.1.  This is a copyleft license and derivatives from  sources here (whether modified or used as is) must be distributed under SIL OFL 1.1 (my emphasis below):

> "Font Software" refers to the set of files released by the Copyright
Holder(s) under this license and clearly marked as such. This may
include **source files, build scripts and documentation**.

> 5) The Font Software, modified or unmodified, in part or in whole,
**must be distributed entirely under this license, and must not be
distributed under any other license**. The requirement for fonts to
remain under this license does not apply to any document created
using the Font Software.

