### PR TITLE
Fix in charset diff

### DIFF
--- a/src/00-recursive-scripts-for-robofont/checking-similarity-between-fonts/check-for-charset-diff-between-selected-fonts.py
+++ b/src/00-recursive-scripts-for-robofont/checking-similarity-between-fonts/check-for-charset-diff-between-selected-fonts.py
@@ -50,7 +50,7 @@ print("")
 problemGlyphs = []
 
 for glyphName in glyphs.keys():
-    if len(glyphs[glyph.name]) < len(fonts):
+    if len(glyphs[glyphName]) < len(fonts):
         if glyphName not in problemGlyphs and glyphName not in glyphsToIgnore.split(" "):
             problemGlyphs.append(glyphName)
 


### PR DESCRIPTION
When I initially ran this script on masters that I *knew* didn't have the same charset, it kept returning an "all good" statement.

I made this little change, and it now returns the list of glyphs that aren't present in all masters. :D