### PR TITLE
Make fractionbar work in statics

### DIFF
--- a/mastering/build_static.py
+++ b/mastering/build_static.py
@@ -267,6 +267,8 @@ def writeFeature(font):
            f'    Vendor "{font.info.openTypeOS2VendorID}";\n'
            f"}} OS/2;\n\n")
 
+    cmap = "feature ccmp {\n    sub slash by slash.split;\n}ccmp;"
+
     split = font.info.postscriptFullName.split()
 
     if "Italic" in split and "Mono" not in split and "Mn" not in split:
@@ -277,6 +279,8 @@ def writeFeature(font):
         includes = ("include (../../features.family);\n"
                     "include (../../features_roman.fea);\n"
                     "include (kern.fea);\n")
+    if "Sn" in split:
+        includes += cmap
     out = hhea + os2 + includes
     with open(path, "w") as f:
         f.write(out)

--- a/mastering/prep_fonts.py
+++ b/mastering/prep_fonts.py
@@ -243,6 +243,8 @@ def decomposeNonExportingGlyphs(fonts):
                     elif component.baseGlyph[0] == "_":
                         non_exporting.append(component.baseGlyph)
                         component.decompose()
+        if "slash.split" in font.keys():
+            font["slash.split"].decompose()
         # add glyphs from lib.skipExportGlyphs
         non_exporting.extend(font.lib["public.skipExportGlyphs"])
         removeGlyphs(font, non_exporting)


### PR DESCRIPTION
1. Decomposes slash.split to avoid recursive reference when making static UFOs
2. Adds a ccmp feature to correct fractionbar in Sans statics