### PR TITLE
Map slnt to accurate degree angles + adjust rules for this + simplify designspace rules

### DIFF
--- a/src/ufo/recursive-MONO_CASL_wght_slnt_ital--full_gsub.designspace
+++ b/src/ufo/recursive-MONO_CASL_wght_slnt_ital--full_gsub.designspace
@@ -21,7 +21,8 @@
     <axis tag="slnt" name="Slant" minimum="-15" maximum="0" default="0">
       <labelname xml:lang="en">Slant</labelname>
       <map input="-15.000000" output="-15.000000" />
-      <map input="-14.039999" output="-14.999998" />
+      <map input="-14.050000" output="-14.999999" />
+      <map input="-14.040000" output="-14.980000" />
       <map input="-7.020000" output="-7.500000" />
       <map input="0.000000" output="0.000000" />
     </axis>
@@ -33,7 +34,7 @@
     <rule name="mono">
       <conditionset>
         <condition name="Monospace" minimum="0.500000" maximum="1" />
-        <condition name="Slant" minimum="-14.999998" maximum="0" />
+        <condition name="Slant" minimum="-14.985000" maximum="0" />
         <condition name="Cursive" minimum="0" maximum="0.900000" />
       </conditionset>
       <sub name="dotlessi" with="dotlessi.mono" />
@@ -104,7 +105,7 @@
     <rule name="mono autoitalic">
       <conditionset>
         <condition name="Monospace" minimum="0.500000" maximum="1" />
-        <condition name="Slant" minimum="-15" maximum="-14.999999" />
+        <condition name="Slant" minimum="-15" maximum="-14.990000" />
         <condition name="Cursive" minimum="0.100000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />
@@ -458,7 +459,7 @@
     </rule>
     <rule name="sans">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.449999" />
+        <condition name="Monospace" minimum="0" maximum="0.500000" />
         <condition name="Slant" minimum="-15" maximum="0" />
       </conditionset>
       <sub name="zero" with="zero.sans" />
@@ -475,8 +476,8 @@
     </rule>
     <rule name="sans autoroman">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.449999" />
-        <condition name="Slant" minimum="-14.999998" maximum="0" />
+        <condition name="Monospace" minimum="0" maximum="0.500000" />
+        <condition name="Slant" minimum="-14.985000" maximum="0" />
         <condition name="Cursive" minimum="0" maximum="0.900000" />
       </conditionset>
       <sub name="zero" with="zero.sans" />
@@ -485,7 +486,7 @@
     </rule>
     <rule name="sans forceroman">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.449999" />
+        <condition name="Monospace" minimum="0" maximum="0.500000" />
         <condition name="Cursive" minimum="0" maximum="0.090000" />
       </conditionset>
       <sub name="l" with="l.sans" />
@@ -502,8 +503,8 @@
     </rule>
     <rule name="sans autoitalic">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.449999" />
-        <condition name="Slant" minimum="-15" maximum="-14.999999" />
+        <condition name="Monospace" minimum="0" maximum="0.500000" />
+        <condition name="Slant" minimum="-15" maximum="-14.990000" />
         <condition name="Cursive" minimum="0.100000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />
@@ -672,7 +673,7 @@
     </rule>
     <rule name="sans forceitalic">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.449999" />
+        <condition name="Monospace" minimum="0" maximum="0.500000" />
         <condition name="Cursive" minimum="0.900000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />

--- a/src/ufo/recursive-MONO_CASL_wght_slnt_ital--full_gsub.designspace
+++ b/src/ufo/recursive-MONO_CASL_wght_slnt_ital--full_gsub.designspace
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<designspace format="4.0">
+<designspace format="4.1">
   <axes>
     <axis tag="MONO" name="Monospace" minimum="0" maximum="1" default="0">
       <labelname xml:lang="en">Monospace</labelname>
@@ -20,6 +20,10 @@
     </axis>
     <axis tag="slnt" name="Slant" minimum="-15" maximum="0" default="0">
       <labelname xml:lang="en">Slant</labelname>
+      <map input="-15.000000" output="-15.000000" />
+      <map input="-14.039999" output="-14.999998" />
+      <map input="-7.020000" output="-7.500000" />
+      <map input="0.000000" output="0.000000" />
     </axis>
     <axis tag="CRSV" name="Cursive" minimum="0" maximum="1" default="0.500000">
       <labelname xml:lang="en">Cursive</labelname>
@@ -28,9 +32,9 @@
   <rules>
     <rule name="mono">
       <conditionset>
-        <condition name="Monospace" minimum="0.499999999999999" maximum="1" />
-        <condition name="Slant" minimum="-13.99" maximum="0" />
-        <condition name="Cursive" minimum="0" maximum="0.899999999999999" />
+        <condition name="Monospace" minimum="0.500000" maximum="1" />
+        <condition name="Slant" minimum="-14.999998" maximum="0" />
+        <condition name="Cursive" minimum="0" maximum="0.900000" />
       </conditionset>
       <sub name="dotlessi" with="dotlessi.mono" />
       <sub name="f" with="f.mono" />
@@ -69,8 +73,8 @@
     </rule>
     <rule name="mono forceroman">
       <conditionset>
-        <condition name="Monospace" minimum="0.499999999999999" maximum="1" />
-        <condition name="Cursive" minimum="0" maximum="0.089999999999999" />
+        <condition name="Monospace" minimum="0.500000" maximum="1" />
+        <condition name="Cursive" minimum="0" maximum="0.090000" />
       </conditionset>
       <sub name="dotlessi" with="dotlessi.mono" />
       <sub name="f" with="f.mono" />
@@ -99,9 +103,9 @@
     </rule>
     <rule name="mono autoitalic">
       <conditionset>
-        <condition name="Monospace" minimum="0.499999999999999" maximum="1" />
-        <condition name="Slant" minimum="-15" maximum="-14" />
-        <condition name="Cursive" minimum="0.1" maximum="1" />
+        <condition name="Monospace" minimum="0.500000" maximum="1" />
+        <condition name="Slant" minimum="-15" maximum="-14.999999" />
+        <condition name="Cursive" minimum="0.100000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />
       <sub name="aacute" with="aacute.italic" />
@@ -277,8 +281,8 @@
     </rule>
     <rule name="mono forceitalic">
       <conditionset>
-        <condition name="Monospace" minimum="0.499999999999999" maximum="1" />
-        <condition name="Cursive" minimum="0.9" maximum="1" />
+        <condition name="Monospace" minimum="0.500000" maximum="1" />
+        <condition name="Cursive" minimum="0.900000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />
       <sub name="aacute" with="aacute.italic" />
@@ -454,13 +458,12 @@
     </rule>
     <rule name="sans">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.499999999999999" />
+        <condition name="Monospace" minimum="0" maximum="0.449999" />
         <condition name="Slant" minimum="-15" maximum="0" />
       </conditionset>
       <sub name="zero" with="zero.sans" />
       <sub name="zerosuperior" with="zerosuperior.sans" />
       <sub name="zeroinferior" with="zeroinferior.sans" />
-      <!-- <sub name="slash" with="slash.split" /> -->
       <sub name="l" with="l.sans" />
       <sub name="lcaron" with="lcaron.sans" />
       <sub name="ldot" with="ldot.sans" />
@@ -472,19 +475,18 @@
     </rule>
     <rule name="sans autoroman">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.499999999999999" />
-        <condition name="Slant" minimum="-13.99" maximum="0" />
-        <condition name="Cursive" minimum="0" maximum="0.899999999999999" />
+        <condition name="Monospace" minimum="0" maximum="0.449999" />
+        <condition name="Slant" minimum="-14.999998" maximum="0" />
+        <condition name="Cursive" minimum="0" maximum="0.900000" />
       </conditionset>
       <sub name="zero" with="zero.sans" />
       <sub name="zerosuperior" with="zerosuperior.sans" />
       <sub name="zeroinferior" with="zeroinferior.sans" />
-      <!-- <sub name="slash" with="slash.split" /> -->
     </rule>
     <rule name="sans forceroman">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.499999999999999" />
-        <condition name="Cursive" minimum="0" maximum="0.089999999999999" />
+        <condition name="Monospace" minimum="0" maximum="0.449999" />
+        <condition name="Cursive" minimum="0" maximum="0.090000" />
       </conditionset>
       <sub name="l" with="l.sans" />
       <sub name="ldot" with="ldot.sans" />
@@ -497,13 +499,12 @@
       <sub name="zero" with="zero.sans" />
       <sub name="zerosuperior" with="zerosuperior.sans" />
       <sub name="zeroinferior" with="zeroinferior.sans" />
-      <!-- <sub name="slash" with="slash.split" /> -->
     </rule>
     <rule name="sans autoitalic">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.499999999999999" />
-        <condition name="Slant" minimum="-15" maximum="-14" />
-        <condition name="Cursive" minimum="0.1" maximum="1" />
+        <condition name="Monospace" minimum="0" maximum="0.449999" />
+        <condition name="Slant" minimum="-15" maximum="-14.999999" />
+        <condition name="Cursive" minimum="0.100000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />
       <sub name="aacute" with="aacute.italic" />
@@ -671,8 +672,8 @@
     </rule>
     <rule name="sans forceitalic">
       <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.499999999999999" />
-        <condition name="Cursive" minimum="0.9" maximum="1" />
+        <condition name="Monospace" minimum="0" maximum="0.449999" />
+        <condition name="Cursive" minimum="0.900000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />
       <sub name="aacute" with="aacute.italic" />

--- a/src/ufo/recursive-MONO_CASL_wght_slnt_ital--full_gsub.designspace
+++ b/src/ufo/recursive-MONO_CASL_wght_slnt_ital--full_gsub.designspace
@@ -37,6 +37,10 @@
         <condition name="Slant" minimum="-14.985000" maximum="0" />
         <condition name="Cursive" minimum="0" maximum="0.900000" />
       </conditionset>
+      <conditionset>
+        <condition name="Monospace" minimum="0.500000" maximum="1" />
+        <condition name="Cursive" minimum="0" maximum="0.090000" />
+      </conditionset>
       <sub name="dotlessi" with="dotlessi.mono" />
       <sub name="f" with="f.mono" />
       <sub name="g" with="g.mono" />
@@ -72,215 +76,12 @@
       <sub name="rinvertedbreve" with="rinvertedbreve.mono" />
       <sub name="rlinebelow" with="rlinebelow.mono" />
     </rule>
-    <rule name="mono forceroman">
-      <conditionset>
-        <condition name="Monospace" minimum="0.500000" maximum="1" />
-        <condition name="Cursive" minimum="0" maximum="0.090000" />
-      </conditionset>
-      <sub name="dotlessi" with="dotlessi.mono" />
-      <sub name="f" with="f.mono" />
-      <sub name="g" with="g.mono" />
-      <sub name="i" with="i.mono" />
-      <sub name="iacute" with="iacute.mono" />
-      <sub name="ibreve" with="ibreve.mono" />
-      <sub name="icircumflex" with="icircumflex.mono" />
-      <sub name="idieresis" with="idieresis.mono" />
-      <sub name="idotbelow" with="idotbelow.mono" />
-      <sub name="igrave" with="igrave.mono" />
-      <sub name="ihook" with="ihook.mono" />
-      <sub name="imacron" with="imacron.mono" />
-      <sub name="iogonek" with="iogonek.mono" />
-      <sub name="itilde" with="itilde.mono" />
-      <sub name="l" with="l.mono" />
-      <sub name="ldot" with="ldot.mono" />
-      <sub name="lcaron" with="lcaron.mono" />
-      <sub name="lacute" with="lacute.mono" />
-      <sub name="lcommaaccent" with="lcommaaccent.mono" />
-      <sub name="lslash" with="lslash.mono" />
-      <sub name="r" with="r.mono" />
-      <sub name="racute" with="racute.mono" />
-      <sub name="rcaron" with="rcaron.mono" />
-      <sub name="rcommaaccent" with="rcommaaccent.mono" />
-    </rule>
     <rule name="mono autoitalic">
       <conditionset>
         <condition name="Monospace" minimum="0.500000" maximum="1" />
         <condition name="Slant" minimum="-15" maximum="-14.990000" />
         <condition name="Cursive" minimum="0.100000" maximum="1" />
       </conditionset>
-      <sub name="a" with="a.italic" />
-      <sub name="aacute" with="aacute.italic" />
-      <sub name="abreve" with="abreve.italic" />
-      <sub name="abreveacute" with="abreveacute.italic" />
-      <sub name="abrevedot" with="abrevedot.italic" />
-      <sub name="abrevegrave" with="abrevegrave.italic" />
-      <sub name="abrevehook" with="abrevehook.italic" />
-      <sub name="abrevetilde" with="abrevetilde.italic" />
-      <sub name="acircumflex" with="acircumflex.italic" />
-      <sub name="acircumflexacute" with="acircumflexacute.italic" />
-      <sub name="acircumflexdot" with="acircumflexdot.italic" />
-      <sub name="acircumflexgrave" with="acircumflexgrave.italic" />
-      <sub name="acircumflexhook" with="acircumflexhook.italic" />
-      <sub name="acircumflextilde" with="acircumflextilde.italic" />
-      <sub name="adieresis" with="adieresis.italic" />
-      <sub name="adotbelow" with="adotbelow.italic" />
-      <sub name="agrave" with="agrave.italic" />
-      <sub name="ahook" with="ahook.italic" />
-      <sub name="amacron" with="amacron.italic" />
-      <sub name="aogonek" with="aogonek.italic" />
-      <sub name="aring" with="aring.italic" />
-      <sub name="aringacute" with="aringacute.italic" />
-      <sub name="atilde" with="atilde.italic" />
-      <sub name="b" with="b.italic" />
-      <sub name="c" with="c.italic" />
-      <sub name="cacute" with="cacute.italic" />
-      <sub name="ccaron" with="ccaron.italic" />
-      <sub name="ccedilla" with="ccedilla.italic" />
-      <sub name="ccircumflex" with="ccircumflex.italic" />
-      <sub name="cdotaccent" with="cdotaccent.italic" />
-      <sub name="d" with="d.italic" />
-      <sub name="dcaron" with="dcaron.italic" />
-      <sub name="dotlessi" with="dotlessi.italic" />
-      <sub name="dotlessj" with="dotlessj.italic" />
-      <sub name="e" with="e.italic" />
-      <sub name="eacute" with="eacute.italic" />
-      <sub name="ebreve" with="ebreve.italic" />
-      <sub name="ecaron" with="ecaron.italic" />
-      <sub name="ecircumflex" with="ecircumflex.italic" />
-      <sub name="ecircumflexacute" with="ecircumflexacute.italic" />
-      <sub name="ecircumflexdot" with="ecircumflexdot.italic" />
-      <sub name="ecircumflexgrave" with="ecircumflexgrave.italic" />
-      <sub name="ecircumflexhook" with="ecircumflexhook.italic" />
-      <sub name="ecircumflextilde" with="ecircumflextilde.italic" />
-      <sub name="edieresis" with="edieresis.italic" />
-      <sub name="edotaccent" with="edotaccent.italic" />
-      <sub name="edotbelow" with="edotbelow.italic" />
-      <sub name="egrave" with="egrave.italic" />
-      <sub name="ehook" with="ehook.italic" />
-      <sub name="emacron" with="emacron.italic" />
-      <sub name="emacronacute" with="emacronacute.italic" />
-      <sub name="emacrongrave" with="emacrongrave.italic" />
-      <sub name="eogonek" with="eogonek.italic" />
-      <sub name="etilde" with="etilde.italic" />
-      <sub name="f" with="f.italic" />
-      <sub name="g" with="g.italic" />
-      <sub name="gbreve" with="gbreve.italic" />
-      <sub name="gcaron" with="gcaron.italic" />
-      <sub name="gcircumflex" with="gcircumflex.italic" />
-      <sub name="gcommaaccent" with="gcommaaccent.italic" />
-      <sub name="gdotaccent" with="gdotaccent.italic" />
-      <sub name="h" with="h.italic" />
-      <sub name="hcircumflex" with="hcircumflex.italic" />
-      <sub name="i" with="i.italic" />
-      <sub name="iacute" with="iacute.italic" />
-      <sub name="ibreve" with="ibreve.italic" />
-      <sub name="icircumflex" with="icircumflex.italic" />
-      <sub name="idieresis" with="idieresis.italic" />
-      <sub name="idotbelow" with="idotbelow.italic" />
-      <sub name="igrave" with="igrave.italic" />
-      <sub name="ihook" with="ihook.italic" />
-      <sub name="imacron" with="imacron.italic" />
-      <sub name="iogonek" with="iogonek.italic" />
-      <sub name="itilde" with="itilde.italic" />
-      <sub name="j" with="j.italic" />
-      <sub name="jcircumflex" with="jcircumflex.italic" />
-      <sub name="k" with="k.italic" />
-      <sub name="kcommaaccent" with="kcommaaccent.italic" />
-      <sub name="l" with="l.italic" />
-      <sub name="ldot" with="ldot.italic" />
-      <sub name="lcaron" with="lcaron.italic" />
-      <sub name="lacute" with="lacute.italic" />
-      <sub name="lcommaaccent" with="lcommaaccent.italic" />
-      <sub name="lslash" with="lslash.italic" />
-      <sub name="m" with="m.italic" />
-      <sub name="n" with="n.italic" />
-      <sub name="nacute" with="nacute.italic" />
-      <sub name="napostrophe" with="napostrophe.italic" />
-      <sub name="ncaron" with="ncaron.italic" />
-      <sub name="ncommaaccent" with="ncommaaccent.italic" />
-      <sub name="ntilde" with="ntilde.italic" />
-      <sub name="r" with="r.italic" />
-      <sub name="racute" with="racute.italic" />
-      <sub name="rcaron" with="rcaron.italic" />
-      <sub name="rcommaaccent" with="rcommaaccent.italic" />
-      <sub name="s" with="s.italic" />
-      <sub name="sacute" with="sacute.italic" />
-      <sub name="scaron" with="scaron.italic" />
-      <sub name="scedilla" with="scedilla.italic" />
-      <sub name="scircumflex" with="scircumflex.italic" />
-      <sub name="scommaaccent" with="scommaaccent.italic" />
-      <sub name="u" with="u.italic" />
-      <sub name="uacute" with="uacute.italic" />
-      <sub name="ubreve" with="ubreve.italic" />
-      <sub name="ucircumflex" with="ucircumflex.italic" />
-      <sub name="udieresis" with="udieresis.italic" />
-      <sub name="udotbelow" with="udotbelow.italic" />
-      <sub name="ugrave" with="ugrave.italic" />
-      <sub name="uhook" with="uhook.italic" />
-      <sub name="uhorn" with="uhorn.italic" />
-      <sub name="uhornacute" with="uhornacute.italic" />
-      <sub name="uhorndot" with="uhorndot.italic" />
-      <sub name="uhorngrave" with="uhorngrave.italic" />
-      <sub name="uhornhook" with="uhornhook.italic" />
-      <sub name="uhorntilde" with="uhorntilde.italic" />
-      <sub name="uhungarumlaut" with="uhungarumlaut.italic" />
-      <sub name="umacron" with="umacron.italic" />
-      <sub name="uogonek" with="uogonek.italic" />
-      <sub name="uring" with="uring.italic" />
-      <sub name="utilde" with="utilde.italic" />
-      <sub name="v" with="v.italic" />
-      <sub name="w" with="w.italic" />
-      <sub name="wacute" with="wacute.italic" />
-      <sub name="wcircumflex" with="wcircumflex.italic" />
-      <sub name="wdieresis" with="wdieresis.italic" />
-      <sub name="wgrave" with="wgrave.italic" />
-      <sub name="x" with="x.italic" />
-      <sub name="y" with="y.italic" />
-      <sub name="yacute" with="yacute.italic" />
-      <sub name="ycircumflex" with="ycircumflex.italic" />
-      <sub name="ydieresis" with="ydieresis.italic" />
-      <sub name="ydotbelow" with="ydotbelow.italic" />
-      <sub name="ygrave" with="ygrave.italic" />
-      <sub name="yhookabove" with="yhookabove.italic" />
-      <sub name="ymacron" with="ymacron.italic" />
-      <sub name="ytilde" with="ytilde.italic" />
-      <sub name="z" with="z.italic" />
-      <sub name="zacute" with="zacute.italic" />
-      <sub name="zcaron" with="zcaron.italic" />
-      <sub name="zdotaccent" with="zdotaccent.italic" />
-      <sub name="agravedbl" with="agravedbl.italic" />
-      <sub name="ddotbelow" with="ddotbelow.italic" />
-      <sub name="dlinebelow" with="dlinebelow.italic" />
-      <sub name="sdot" with="sdot.italic" />
-      <sub name="sdotbelow" with="sdotbelow.italic" />
-      <sub name="sacutedotaccent" with="sacutedotaccent.italic" />
-      <sub name="scarondot" with="scarondot.italic" />
-      <sub name="sdotbelowdotabove" with="sdotbelowdotabove.italic" />
-      <sub name="utildeacute" with="utildeacute.italic" />
-      <sub name="umacrondieresis" with="umacrondieresis.italic" />
-      <sub name="rlinebelow" with="rlinebelow.italic" />
-      <sub name="rgravedbl" with="rgravedbl.italic" />
-      <sub name="rinvertedbreve" with="rinvertedbreve.italic" />
-      <sub name="rdotbelow" with="rdotbelow.italic" />
-      <sub name="idieresisacute" with="idieresisacute.italic" />
-      <sub name="ecedillabreve" with="ecedillabreve.italic" />
-      <sub name="ccedillaacute" with="ccedillaacute.italic" />
-      <sub name="egravedbl" with="egravedbl.italic" />
-      <sub name="einvertedbreve" with="einvertedbreve.italic" />
-      <sub name="igravedbl" with="igravedbl.italic" />
-      <sub name="iinvertedbreve" with="iinvertedbreve.italic" />
-      <sub name="ugravedbl" with="ugravedbl.italic" />
-      <sub name="uinvertedbreve" with="uinvertedbreve.italic" />
-      <sub name="ydot" with="ydot.italic" />
-      <sub name="zdotbelow" with="zdotbelow.italic" />
-      <sub name="mdotbelow" with="mdotbelow.italic" />
-      <sub name="ndot" with="ndot.italic" />
-      <sub name="ndotbelow" with="ndotbelow.italic" />
-      <sub name="nlinebelow" with="nlinebelow.italic" />
-      <sub name="gmacron" with="gmacron.italic" />
-      <sub name="hdotbelow" with="hdotbelow.italic" />
-    </rule>
-    <rule name="mono forceitalic">
       <conditionset>
         <condition name="Monospace" minimum="0.500000" maximum="1" />
         <condition name="Cursive" minimum="0.900000" maximum="1" />
@@ -380,6 +181,10 @@
       <sub name="racute" with="racute.italic" />
       <sub name="rcaron" with="rcaron.italic" />
       <sub name="rcommaaccent" with="rcommaaccent.italic" />
+      <sub name="rdotbelow" with="rdotbelow.italic" />
+      <sub name="rgravedbl" with="rgravedbl.italic" />
+      <sub name="rinvertedbreve" with="rinvertedbreve.italic" />
+      <sub name="rlinebelow" with="rlinebelow.italic" />
       <sub name="s" with="s.italic" />
       <sub name="sacute" with="sacute.italic" />
       <sub name="scaron" with="scaron.italic" />
@@ -462,50 +267,36 @@
         <condition name="Monospace" minimum="0" maximum="0.500000" />
         <condition name="Slant" minimum="-15" maximum="0" />
       </conditionset>
-      <sub name="zero" with="zero.sans" />
-      <sub name="zerosuperior" with="zerosuperior.sans" />
-      <sub name="zeroinferior" with="zeroinferior.sans" />
-      <sub name="l" with="l.sans" />
-      <sub name="lcaron" with="lcaron.sans" />
-      <sub name="ldot" with="ldot.sans" />
-      <sub name="lacute" with="lacute.sans" />
-      <sub name="lcommaaccent" with="lcommaaccent.sans" />
-      <sub name="ldotbelow" with="ldotbelow.sans" />
-      <sub name="llinebelow" with="llinebelow.sans" />
-      <sub name="lslash" with="lslash.sans" />
-    </rule>
-    <rule name="sans autoroman">
       <conditionset>
         <condition name="Monospace" minimum="0" maximum="0.500000" />
         <condition name="Slant" minimum="-14.985000" maximum="0" />
         <condition name="Cursive" minimum="0" maximum="0.900000" />
       </conditionset>
-      <sub name="zero" with="zero.sans" />
-      <sub name="zerosuperior" with="zerosuperior.sans" />
-      <sub name="zeroinferior" with="zeroinferior.sans" />
-    </rule>
-    <rule name="sans forceroman">
       <conditionset>
         <condition name="Monospace" minimum="0" maximum="0.500000" />
         <condition name="Cursive" minimum="0" maximum="0.090000" />
       </conditionset>
+      <sub name="zero" with="zero.sans" />
+      <sub name="zerosuperior" with="zerosuperior.sans" />
+      <sub name="zeroinferior" with="zeroinferior.sans" />
       <sub name="l" with="l.sans" />
-      <sub name="ldot" with="ldot.sans" />
       <sub name="lcaron" with="lcaron.sans" />
+      <sub name="ldot" with="ldot.sans" />
       <sub name="lacute" with="lacute.sans" />
       <sub name="lcommaaccent" with="lcommaaccent.sans" />
       <sub name="ldotbelow" with="ldotbelow.sans" />
       <sub name="llinebelow" with="llinebelow.sans" />
       <sub name="lslash" with="lslash.sans" />
-      <sub name="zero" with="zero.sans" />
-      <sub name="zerosuperior" with="zerosuperior.sans" />
-      <sub name="zeroinferior" with="zeroinferior.sans" />
     </rule>
     <rule name="sans autoitalic">
       <conditionset>
         <condition name="Monospace" minimum="0" maximum="0.500000" />
         <condition name="Slant" minimum="-15" maximum="-14.990000" />
         <condition name="Cursive" minimum="0.100000" maximum="1" />
+      </conditionset>
+      <conditionset>
+        <condition name="Monospace" minimum="0" maximum="0.500000" />
+        <condition name="Cursive" minimum="0.900000" maximum="1" />
       </conditionset>
       <sub name="a" with="a.italic" />
       <sub name="aacute" with="aacute.italic" />
@@ -589,182 +380,6 @@
       <sub name="itilde" with="itilde.italic" />
       <sub name="k" with="k.italic" />
       <sub name="kcommaaccent" with="kcommaaccent.italic" />
-      <sub name="m" with="m.italic" />
-      <sub name="mdotbelow" with="mdotbelow.italic" />
-      <sub name="n" with="n.italic" />
-      <sub name="nacute" with="nacute.italic" />
-      <sub name="napostrophe" with="napostrophe.italic" />
-      <sub name="ncaron" with="ncaron.italic" />
-      <sub name="ncommaaccent" with="ncommaaccent.italic" />
-      <sub name="ndot" with="ndot.italic" />
-      <sub name="ndotbelow" with="ndotbelow.italic" />
-      <sub name="nlinebelow" with="nlinebelow.italic" />
-      <sub name="ntilde" with="ntilde.italic" />
-      <sub name="u" with="u.italic" />
-      <sub name="uacute" with="uacute.italic" />
-      <sub name="ubreve" with="ubreve.italic" />
-      <sub name="ucircumflex" with="ucircumflex.italic" />
-      <sub name="udieresis" with="udieresis.italic" />
-      <sub name="udotbelow" with="udotbelow.italic" />
-      <sub name="ugrave" with="ugrave.italic" />
-      <sub name="ugravedbl" with="ugravedbl.italic" />
-      <sub name="uhook" with="uhook.italic" />
-      <sub name="uhorn" with="uhorn.italic" />
-      <sub name="uhornacute" with="uhornacute.italic" />
-      <sub name="uhorndot" with="uhorndot.italic" />
-      <sub name="uhorngrave" with="uhorngrave.italic" />
-      <sub name="uhornhook" with="uhornhook.italic" />
-      <sub name="uhorntilde" with="uhorntilde.italic" />
-      <sub name="uhungarumlaut" with="uhungarumlaut.italic" />
-      <sub name="uinvertedbreve" with="uinvertedbreve.italic" />
-      <sub name="umacron" with="umacron.italic" />
-      <sub name="umacrondieresis" with="umacrondieresis.italic" />
-      <sub name="uogonek" with="uogonek.italic" />
-      <sub name="uring" with="uring.italic" />
-      <sub name="utilde" with="utilde.italic" />
-      <sub name="utildeacute" with="utildeacute.italic" />
-      <sub name="v" with="v.italic" />
-      <sub name="w" with="w.italic" />
-      <sub name="wacute" with="wacute.italic" />
-      <sub name="wcircumflex" with="wcircumflex.italic" />
-      <sub name="wdieresis" with="wdieresis.italic" />
-      <sub name="wgrave" with="wgrave.italic" />
-      <sub name="x" with="x.italic" />
-      <sub name="y" with="y.italic" />
-      <sub name="yacute" with="yacute.italic" />
-      <sub name="ycircumflex" with="ycircumflex.italic" />
-      <sub name="ydieresis" with="ydieresis.italic" />
-      <sub name="ydot" with="ydot.italic" />
-      <sub name="ydotbelow" with="ydotbelow.italic" />
-      <sub name="ygrave" with="ygrave.italic" />
-      <sub name="yhookabove" with="yhookabove.italic" />
-      <sub name="ymacron" with="ymacron.italic" />
-      <sub name="ytilde" with="ytilde.italic" />
-      <sub name="agravedbl" with="agravedbl.italic" />
-      <sub name="ddotbelow" with="ddotbelow.italic" />
-      <sub name="dlinebelow" with="dlinebelow.italic" />
-      <sub name="utildeacute" with="utildeacute.italic" />
-      <sub name="umacrondieresis" with="umacrondieresis.italic" />
-      <sub name="idieresisacute" with="idieresisacute.italic" />
-      <sub name="ecedillabreve" with="ecedillabreve.italic" />
-      <sub name="egravedbl" with="egravedbl.italic" />
-      <sub name="einvertedbreve" with="einvertedbreve.italic" />
-      <sub name="igravedbl" with="igravedbl.italic" />
-      <sub name="iinvertedbreve" with="iinvertedbreve.italic" />
-      <sub name="ugravedbl" with="ugravedbl.italic" />
-      <sub name="uinvertedbreve" with="uinvertedbreve.italic" />
-      <sub name="ydot" with="ydot.italic" />
-      <sub name="mdotbelow" with="mdotbelow.italic" />
-      <sub name="ndot" with="ndot.italic" />
-      <sub name="ndotbelow" with="ndotbelow.italic" />
-      <sub name="nlinebelow" with="nlinebelow.italic" />
-      <sub name="gmacron" with="gmacron.italic" />
-      <sub name="hdotbelow" with="hdotbelow.italic" />
-      <sub name="zero" with="zero.sans" />
-      <sub name="zerosuperior" with="zerosuperior.sans" />
-      <sub name="zeroinferior" with="zeroinferior.sans" />
-      <sub name="z" with="z.italic" />
-      <sub name="zacute" with="zacute.italic" />
-      <sub name="zcaron" with="zcaron.italic" />
-      <sub name="zdotaccent" with="zdotaccent.italic" />
-      <sub name="dz" with="dz.italic" />
-      <sub name="dzcaron" with="dzcaron.italic" />
-      <sub name="q" with="q.italic" />
-    </rule>
-    <rule name="sans forceitalic">
-      <conditionset>
-        <condition name="Monospace" minimum="0" maximum="0.500000" />
-        <condition name="Cursive" minimum="0.900000" maximum="1" />
-      </conditionset>
-      <sub name="a" with="a.italic" />
-      <sub name="aacute" with="aacute.italic" />
-      <sub name="abreve" with="abreve.italic" />
-      <sub name="abreveacute" with="abreveacute.italic" />
-      <sub name="abrevedot" with="abrevedot.italic" />
-      <sub name="abrevegrave" with="abrevegrave.italic" />
-      <sub name="abrevehook" with="abrevehook.italic" />
-      <sub name="abrevetilde" with="abrevetilde.italic" />
-      <sub name="acircumflex" with="acircumflex.italic" />
-      <sub name="acircumflexacute" with="acircumflexacute.italic" />
-      <sub name="acircumflexdot" with="acircumflexdot.italic" />
-      <sub name="acircumflexgrave" with="acircumflexgrave.italic" />
-      <sub name="acircumflexhook" with="acircumflexhook.italic" />
-      <sub name="acircumflextilde" with="acircumflextilde.italic" />
-      <sub name="adieresis" with="adieresis.italic" />
-      <sub name="adotbelow" with="adotbelow.italic" />
-      <sub name="agrave" with="agrave.italic" />
-      <sub name="agravedbl" with="agravedbl.italic" />
-      <sub name="ahook" with="ahook.italic" />
-      <sub name="ainvertedbreve" with="ainvertedbreve.italic" />
-      <sub name="amacron" with="amacron.italic" />
-      <sub name="aogonek" with="aogonek.italic" />
-      <sub name="aring" with="aring.italic" />
-      <sub name="aringacute" with="aringacute.italic" />
-      <sub name="atilde" with="atilde.italic" />
-      <sub name="b" with="b.italic" />
-      <sub name="d" with="d.italic" />
-      <sub name="dcaron" with="dcaron.italic" />
-      <sub name="ddotbelow" with="ddotbelow.italic" />
-      <sub name="dlinebelow" with="dlinebelow.italic" />
-      <sub name="e" with="e.italic" />
-      <sub name="eacute" with="eacute.italic" />
-      <sub name="ebreve" with="ebreve.italic" />
-      <sub name="ecaron" with="ecaron.italic" />
-      <sub name="ecedillabreve" with="ecedillabreve.italic" />
-      <sub name="ecircumflex" with="ecircumflex.italic" />
-      <sub name="ecircumflexacute" with="ecircumflexacute.italic" />
-      <sub name="ecircumflexdot" with="ecircumflexdot.italic" />
-      <sub name="ecircumflexgrave" with="ecircumflexgrave.italic" />
-      <sub name="ecircumflexhook" with="ecircumflexhook.italic" />
-      <sub name="ecircumflextilde" with="ecircumflextilde.italic" />
-      <sub name="edieresis" with="edieresis.italic" />
-      <sub name="edotaccent" with="edotaccent.italic" />
-      <sub name="edotbelow" with="edotbelow.italic" />
-      <sub name="egrave" with="egrave.italic" />
-      <sub name="egravedbl" with="egravedbl.italic" />
-      <sub name="ehook" with="ehook.italic" />
-      <sub name="einvertedbreve" with="einvertedbreve.italic" />
-      <sub name="emacron" with="emacron.italic" />
-      <sub name="emacronacute" with="emacronacute.italic" />
-      <sub name="emacrongrave" with="emacrongrave.italic" />
-      <sub name="eogonek" with="eogonek.italic" />
-      <sub name="etilde" with="etilde.italic" />
-      <sub name="g" with="g.italic" />
-      <sub name="gbreve" with="gbreve.italic" />
-      <sub name="gcaron" with="gcaron.italic" />
-      <sub name="gcircumflex" with="gcircumflex.italic" />
-      <sub name="gcommaaccent" with="gcommaaccent.italic" />
-      <sub name="gdotaccent" with="gdotaccent.italic" />
-      <sub name="gmacron" with="gmacron.italic" />
-      <sub name="h" with="h.italic" />
-      <sub name="hbrevebelow" with="hbrevebelow.italic" />
-      <sub name="hcircumflex" with="hcircumflex.italic" />
-      <sub name="hdotbelow" with="hdotbelow.italic" />
-      <sub name="i" with="i.italic" />
-      <sub name="iacute" with="iacute.italic" />
-      <sub name="ibreve" with="ibreve.italic" />
-      <sub name="icircumflex" with="icircumflex.italic" />
-      <sub name="idieresis" with="idieresis.italic" />
-      <sub name="idieresisacute" with="idieresisacute.italic" />
-      <sub name="idotaccent" with="idotaccent.italic" />
-      <sub name="idotbelow" with="idotbelow.italic" />
-      <sub name="igrave" with="igrave.italic" />
-      <sub name="igravedbl" with="igravedbl.italic" />
-      <sub name="ihook" with="ihook.italic" />
-      <sub name="iinvertedbreve" with="iinvertedbreve.italic" />
-      <sub name="imacron" with="imacron.italic" />
-      <sub name="iogonek" with="iogonek.italic" />
-      <sub name="itilde" with="itilde.italic" />
-      <sub name="k" with="k.italic" />
-      <sub name="kcommaaccent" with="kcommaaccent.italic" />
-      <sub name="l" with="l.sans" />
-      <sub name="ldot" with="ldot.sans" />
-      <sub name="lcaron" with="lcaron.sans" />
-      <sub name="lacute" with="lacute.sans" />
-      <sub name="lcommaaccent" with="lcommaaccent.sans" />
-      <sub name="ldotbelow" with="ldotbelow.sans" />
-      <sub name="llinebelow" with="llinebelow.sans" />
-      <sub name="lslash" with="lslash.sans" />
       <sub name="m" with="m.italic" />
       <sub name="mdotbelow" with="mdotbelow.italic" />
       <sub name="n" with="n.italic" />


### PR DESCRIPTION
This updates the designspace in such a way that will address https://github.com/arrowtype/recursive/issues/59. See that issue for more information.

It also simplifies designspace rules by using multiple conditionsets for related rules. 

It doesn’t yet build a new release, as I intend to make a couple more improvements before doing so.